### PR TITLE
Only use the pagination cursor when determining subscription costs exhaustion

### DIFF
--- a/sync_resources.py
+++ b/sync_resources.py
@@ -348,13 +348,9 @@ class SubscriptionCostsCursor(AbstractCursor):
 
     def pagination_exhausted(self) -> bool:
         """
-        Pagination is exhausted if we have < 1 day in our timeframe.
+        Pagination is exhausted if we no longer have a cursor for paginating.
         """
-        is_exhausted = (
-            self.current_subscriptions_pagination_cursor is None
-            and (self.current_timeframe_end - self.current_timeframe_start).days < 1
-        )
-        return is_exhausted
+        return self.current_subscriptions_pagination_cursor is None
 
 
 T = TypeVar("T", bound=AbstractCursor)


### PR DESCRIPTION
Today, we have cases where costs fetching takes over a day! This isn't great (and we are working to fix it) but our logic for cases where costs timelines are _over_ one day considers costs fetching to be incomplete (i.e. it's a paginated request).

We should amend this logic to only consider the cursor for determining pagination exhaustion so we don't end up in an infinite loop where we're only fetching costs.

The infinite cycle:
- Costs take over a day to fetch
- When current time frame finished, update it to a new time frame that is (end of last time frame, today - 2 days)
- This new time frame is over one day in length
- Consider this a paginated invocation
- Fetch no other resources

Instead, even if we are behind, we should still fetch over sources of data, especially given how cheap they are to fetch in comparison.

I'll make a corresponding change to our managed solution as well.