### PR TITLE
Enable soft delete mode & configurable grace period

### DIFF
--- a/sync_resources.py
+++ b/sync_resources.py
@@ -35,7 +35,7 @@ MAX_PAGES_PER_SYNC = 10
 ## Only applies to costs
 MIN_COSTS_START_TIME = pendulum.datetime(2023, 1, 1, 0, 0, 0, tz="UTC")
 COSTS_TIMEFRAME_WINDOW = 10
-GRACE_PERIOD_BUFFER_DAYS = 2
+GRACE_PERIOD_BUFFER_HOURS = int(os.environ.get("GRACE_PERIOD_BUFFER_HOURS", "48"))
 
 ## Subscription Costs
 SUBSCRIPTION_COSTS_PAGE_SIZE = DEFAULT_PAGE_SIZE
@@ -306,7 +306,7 @@ class SubscriptionCostsCursor(AbstractCursor):
     ) -> pendulum.DateTime:
         return min(
             start_time.add(days=COSTS_TIMEFRAME_WINDOW),
-            pendulum.now("UTC").subtract(days=GRACE_PERIOD_BUFFER_DAYS),
+            pendulum.now("UTC").subtract(hours=GRACE_PERIOD_BUFFER_HOURS),
         )
 
     @staticmethod

--- a/sync_resources.py
+++ b/sync_resources.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
@@ -652,6 +653,9 @@ class FivetranFunctionResponse:
         }
     )
     has_more: bool = False
+    softDelete: List = field(
+        default_factory = lambda: json.loads(os.environ.get("SOFT_DELETE_SCHEMAS_JSON", "[]"))
+    )
 
     def as_dict(self, s3_sync=False):
         if s3_sync:
@@ -659,6 +663,7 @@ class FivetranFunctionResponse:
                 "state": self.state.as_dict(),
                 "schema": self.schema,
                 "hasMore": self.has_more,
+                "softDelete": self.softDelete,
             }
         else:
             return {
@@ -667,6 +672,7 @@ class FivetranFunctionResponse:
                 "delete": {},
                 "schema": self.schema,
                 "hasMore": self.has_more,
+                "softDelete": self.softDelete,
             }
 
     def serialize_output_to_s3(self):


### PR DESCRIPTION
This PR introduces two environment variables that can be used to configure the connector:

* SOFT_DELETE_SCHEMAS_JSON contains a JSON list of schemas that will be enabled for softDelete mode. Defaults to an empty list.
* GRACE_PERIOD_BUFFER_HOURS specifies the length of the grace period for `subscription_costs` in hours. Defaults to 48 hours, equivalent to the 2 day grace period currently observed.