### PR TITLE
Ignore excluded resources when determining is_paginated_invocation

### DIFF
--- a/sync_resources.py
+++ b/sync_resources.py
@@ -1331,6 +1331,8 @@ def lambda_handler(req, context):
     incomplete_pagination_resources = set()
     is_paginated_invocation = False
     for resource, resource_config in RESOURCE_TO_RESOURCE_CONFIG.items():
+        if resource in excluded_resources:
+            continue
         state_cursor = state.state_cursor_for_resource(resource)
         if not state_cursor.pagination_exhausted():
             is_paginated_invocation = True


### PR DESCRIPTION
Previously, cursors for excluded resources were considered when determining `is_paginated_invocation`. If any such cursor returned "pagination not exhausted", this would result in the connector never making progress, because the cursors for nonexhausted resources would never be updated.